### PR TITLE
Update pom.xml

### DIFF
--- a/drools-examples/pom.xml
+++ b/drools-examples/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.wordpress.ezegrande</groupId>
 		<artifactId>droolsjbpm-quickstart-guide</artifactId>
-		<version>1.0</version>
+		<version>1.1</version>
 	</parent>
 	<artifactId>drools-examples</artifactId>
 	<packaging>jar</packaging>


### PR DESCRIPTION
 Non-resolvable parent POM for com.wordpress.ezegrande:drools-examples:[unknown-version]: Could not find artifact com.wordpress.ezegrande:droolsjbpm-quickstart-guide:pom:1.0 in central (https://repo.maven.apache.org/maven2) and 'parent.relativePath' points at wrong local POM @ line 4, column 10 -> [Help 2]